### PR TITLE
Update AnsiConsoleExtensions.Input.cs

### DIFF
--- a/src/Spectre.Console.Rx/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
+++ b/src/Spectre.Console.Rx/Spectre.Console/Extensions/AnsiConsoleExtensions.Input.cs
@@ -61,7 +61,10 @@ public static partial class AnsiConsoleExtensions
                 if (text.Length > 0)
                 {
                     text = text.Substring(0, text.Length - 1);
-                    console.Write("\b \b");
+                    if (mask != null)
+                    {
+                        console.Write("\b \b");
+                    }
                 }
 
                 continue;

--- a/src/Tests/BasicUsagesTest.cs
+++ b/src/Tests/BasicUsagesTest.cs
@@ -6,7 +6,6 @@ namespace Tests;
 /// <summary>
 /// BasicUsagesTest.
 /// </summary>
-[UsesVerify]
 public class BasicUsagesTest
 {
     private static readonly List<Student> _students = StudentsGenerator.GenerateStudents();

--- a/src/Tests/OtherUsagesTest.cs
+++ b/src/Tests/OtherUsagesTest.cs
@@ -6,7 +6,6 @@ namespace Tests;
 /// <summary>
 /// OtherUsagesTest.
 /// </summary>
-[UsesVerify]
 public class OtherUsagesTest
 {
     /// <summary>

--- a/src/Tests/Using.Spectre.Console.Rx.Tests.csproj
+++ b/src/Tests/Using.Spectre.Console.Rx.Tests.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
-    <PackageReference Include="Verify.Xunit" Version="22.11.5" />
+    <PackageReference Include="Verify.Xunit" Version="23.2.0" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Don't erase the prompt text when backspacing on a secret prompt with a null mask