### PR TITLE
Delete global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,0 @@
-{
-    "sdk": {
-        "version": "8.0.10",
-        "rollForward": "latestMinor"
-    }
-}


### PR DESCRIPTION
This pull request removes the `global.json` file, which previously specified the .NET SDK version and roll-forward policy. This change may affect how the project determines the SDK version during builds.