### PR TITLE
Update Spectre.Console.Rx

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -49,7 +49,7 @@ partial class Build : NukeBuild
             }
 
             PackagesDirectory.CreateOrCleanDirectory();
-            await this.InstallDotNetSdk("6.x.x", "7.x.x", "8.x.x");
+            await this.InstallDotNetSdk("8.x.x", "9.x.x");
         });
 
     Target Restore => _ => _

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace></RootNamespace>
     <NoWarn>CS0649;CS0169;CA1822;IDE1006;IDE0051</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageDownload Include="nbgv" Version="[3.6.133]" />
+    <PackageDownload Include="nbgv" Version="[3.6.146]" />
   </ItemGroup>
 
 </Project>

--- a/src/Spectre.Console.Rx.Json/Spectre.Console.Rx.Json.csproj
+++ b/src/Spectre.Console.Rx.Json/Spectre.Console.Rx.Json.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>true</ImplicitUsings>
     <Description>A library that extends Spectre.Console with JSON superpowers.</Description>
   </PropertyGroup>

--- a/src/Spectre.Console.Rx.Testing/Spectre.Console.Rx.Testing.csproj
+++ b/src/Spectre.Console.Rx.Testing/Spectre.Console.Rx.Testing.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net7.0;net6.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;netstandard2.0</TargetFrameworks>
     <IsTestProject>false</IsTestProject>
     <Description>Contains testing utilities for Spectre.Console.</Description>
   </PropertyGroup>

--- a/src/Spectre.Console.Rx/Spectre.Console.Rx.csproj
+++ b/src/Spectre.Console.Rx/Spectre.Console.Rx.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>


### PR DESCRIPTION
This pull request updates the target frameworks in the `Spectre.Console.Rx` project file to align with newer .NET versions and drop support for older ones.

Framework updates:

* [`src/Spectre.Console.Rx/Spectre.Console.Rx.csproj`](diffhunk://#diff-9cb944990ea5f7fb10cfa531be17519c71ab0943b6d21b906cb3d001e18c8d13L4-R4): Removed support for `net6.0` and `net7.0` and added support for `net9.0` in the `<TargetFrameworks>` property.